### PR TITLE
Endrer til å bruke BMs fødselsdato som gyldigFom på status UGIFT sivi…

### DIFF
--- a/bidrag-sivilstand/src/main/kotlin/no/nav/bidrag/sivilstand/dto/Sivilstand.kt
+++ b/bidrag-sivilstand/src/main/kotlin/no/nav/bidrag/sivilstand/dto/Sivilstand.kt
@@ -7,6 +7,7 @@ import no.nav.bidrag.transport.behandling.grunnlag.response.SivilstandGrunnlagDt
 import java.time.LocalDate
 
 data class SivilstandRequest(
+    val fødselsdatoBM: LocalDate,
     // Data som er hentet fra PDL. Disse dataene brukes til å beregne offentlige perioder.
     val innhentedeOffentligeOpplysninger: List<SivilstandGrunnlagDto>,
     // Behandlede sivilstandsopplysninger. Dette vil være resultatperioder fra en tidligere beregning.
@@ -15,12 +16,7 @@ data class SivilstandRequest(
     val endreSivilstand: EndreSivilstand?,
 )
 
-data class Sivilstand(
-    val periodeFom: LocalDate,
-    val periodeTom: LocalDate?,
-    val sivilstandskode: Sivilstandskode,
-    val kilde: Kilde,
-)
+data class Sivilstand(val periodeFom: LocalDate, val periodeTom: LocalDate?, val sivilstandskode: Sivilstandskode, val kilde: Kilde)
 
 data class EndreSivilstand(
     val typeEndring: TypeEndring,

--- a/bidrag-sivilstand/src/test/kotlin/no/nav/bidrag/sivilstand/TestUtil.kt
+++ b/bidrag-sivilstand/src/test/kotlin/no/nav/bidrag/sivilstand/TestUtil.kt
@@ -248,6 +248,7 @@ class TestUtil {
         )
 
         fun byggHentSivilstandResponseTestSorteringV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -301,6 +302,7 @@ class TestUtil {
         )
 
         fun byggSivilstandUtenAktivStatusV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -327,6 +329,7 @@ class TestUtil {
         )
 
         fun byggSivilstandMedPeriodeUtenDatoerV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -353,6 +356,7 @@ class TestUtil {
         )
 
         fun byggSivilstandMedAktivForekomstOgKunRegistrertV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -379,6 +383,7 @@ class TestUtil {
         )
 
         fun byggSivilstandÉnForekomstBorAleneMedBarnV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -396,6 +401,7 @@ class TestUtil {
         )
 
         fun byggSivilstandÉnForekomstGiftSamboerV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -413,6 +419,7 @@ class TestUtil {
         )
 
         fun byggSivilstandFlereForekomstBorAleneMedBarnV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -448,6 +455,7 @@ class TestUtil {
         )
 
         fun byggSivilstandMedLogiskFeilV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -474,6 +482,7 @@ class TestUtil {
         )
 
         fun byggSivilstandFlereForkomsterISammeMånedV2() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -509,6 +518,7 @@ class TestUtil {
         )
 
         fun manuellOgOffentligPeriodeErIdentisk() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -545,6 +555,7 @@ class TestUtil {
         fun flereManuelleOgOffentligePerioderFlereRequester() = listOf(
             // 1
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger =
                 listOf(
                     SivilstandGrunnlagDto(
@@ -571,6 +582,7 @@ class TestUtil {
             ),
             // 2
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger =
                 listOf(
                     SivilstandGrunnlagDto(
@@ -620,6 +632,7 @@ class TestUtil {
             ),
             // 3
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger =
                 listOf(
                     SivilstandGrunnlagDto(
@@ -682,6 +695,7 @@ class TestUtil {
         )
 
         fun kunManuellPeriode() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger = emptyList(),
             behandledeSivilstandsopplysninger = emptyList(),
             endreSivilstand = EndreSivilstand(
@@ -699,6 +713,7 @@ class TestUtil {
 
         fun manuellOgOffentligPerioderLikSivilstandskode() = listOf(
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = listOf(
                     SivilstandGrunnlagDto(
                         personId = "98765432109",
@@ -707,7 +722,7 @@ class TestUtil {
                         bekreftelsesdato = null,
                         master = "PDL",
                         registrert = null,
-                        historisk = false,
+                        historisk = true,
                     ),
                     SivilstandGrunnlagDto(
                         personId = "98765432109",
@@ -745,6 +760,7 @@ class TestUtil {
                 ),
             ),
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = listOf(
                     SivilstandGrunnlagDto(
                         personId = "98765432109",
@@ -753,7 +769,7 @@ class TestUtil {
                         bekreftelsesdato = null,
                         master = "PDL",
                         registrert = null,
-                        historisk = false,
+                        historisk = true,
                     ),
                     SivilstandGrunnlagDto(
                         personId = "98765432109",
@@ -800,6 +816,7 @@ class TestUtil {
 
         fun flereManuellePerioder() = listOf(
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = listOf(
                     Sivilstand(
@@ -821,6 +838,7 @@ class TestUtil {
                 ),
             ),
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = listOf(
                     Sivilstand(
@@ -858,6 +876,7 @@ class TestUtil {
         fun endreSivilstandNullBehandledeUtfylltOffentligeOpplysningerUtfyllt1a1c2a() = listOf(
             // 1c
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = listOf(
                     SivilstandGrunnlagDto(
                         personId = "12345678901",
@@ -892,6 +911,7 @@ class TestUtil {
             ),
             // 2a
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = listOf(
                     SivilstandGrunnlagDto(
                         personId = "12345678901",
@@ -948,6 +968,7 @@ class TestUtil {
             ),
             // 1a med oppdaterte offentlige opplysninger og endret virkningstidspunkt
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = listOf(
                     SivilstandGrunnlagDto(
                         personId = "12345678901",
@@ -1018,6 +1039,7 @@ class TestUtil {
 
         fun endreSivilstandNullBehandledeUtfylltOffentligeOpplysningerTom1b() = // 1b
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = listOf(
                     Sivilstand(
@@ -1038,6 +1060,7 @@ class TestUtil {
 
         fun endreSivilstandNullBehandledeTomOffentligeOpplysningerTom1d() = // 1d
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = emptyList(),
                 endreSivilstand = null,
@@ -1045,6 +1068,7 @@ class TestUtil {
 
         fun endreSivilstandUtfylltNYBehandledeUtfylltOffentligeOpplysningerTom2b() = // 1b
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = listOf(
                     Sivilstand(
@@ -1074,6 +1098,7 @@ class TestUtil {
 
         fun endreSivilstandUtfylltENDREBehandledeUtfylltOffentligeOpplysningerTom2b() = // 1b
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = listOf(
                     Sivilstand(
@@ -1108,6 +1133,7 @@ class TestUtil {
 
         fun endreSivilstandUtfylltSLETTBehandledeUtfylltOffentligeOpplysningerTom2b() = // 1b
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = listOf(
                     Sivilstand(
@@ -1143,6 +1169,7 @@ class TestUtil {
 
         fun endreSivilstandUtfylltSLETTMidtperiodeBehandledeUtfylltOffentligeOpplysningerTom2b() = // 1b
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = listOf(
                     Sivilstand(
@@ -1184,6 +1211,7 @@ class TestUtil {
 
         fun endreSivilstandUtfylltBehandledeTomOffentligeOpplysningerUtfyllt2c() = // 1b
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = listOf(
                     SivilstandGrunnlagDto(
                         personId = "12345678901",
@@ -1219,6 +1247,7 @@ class TestUtil {
 
         fun endreSivilstandUtfylltBehandledeTomOffentligeOpplysningerTom2d() = // 1b
             SivilstandRequest(
+                fødselsdatoBM = LocalDate.parse("1980-01-01"),
                 innhentedeOffentligeOpplysninger = emptyList(),
                 behandledeSivilstandsopplysninger = emptyList(),
                 endreSivilstand = EndreSivilstand(
@@ -1234,6 +1263,7 @@ class TestUtil {
             )
 
         fun endreSivilstand() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger = listOf(
                 SivilstandGrunnlagDto(
                     personId = "12345678901",
@@ -1289,6 +1319,7 @@ class TestUtil {
         )
 
         fun endreVirkningstidspunktFremITid() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
             innhentedeOffentligeOpplysninger =
             listOf(
                 SivilstandGrunnlagDto(
@@ -1310,6 +1341,78 @@ class TestUtil {
                     kilde = Kilde.OFFENTLIG,
                 ),
             ),
+            endreSivilstand = null,
+        )
+
+        fun gyldigFomLikFødselsdatoUgift() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
+            innhentedeOffentligeOpplysninger =
+            listOf(
+                SivilstandGrunnlagDto(
+                    personId = "12345678901",
+                    type = SivilstandskodePDL.GIFT,
+                    gyldigFom = LocalDate.of(2022, 12, 9),
+                    bekreftelsesdato = null,
+                    master = "PDL",
+                    registrert = LocalDateTime.parse("2021-01-13T14:44:16"),
+                    historisk = true,
+                ),
+                SivilstandGrunnlagDto(
+                    personId = "12345678901",
+                    type = SivilstandskodePDL.UGIFT,
+                    gyldigFom = null,
+                    bekreftelsesdato = null,
+                    master = "PDL",
+                    registrert = LocalDateTime.parse("2020-12-05T14:44:16"),
+                    historisk = true,
+                ),
+                SivilstandGrunnlagDto(
+                    personId = "12345678901",
+                    type = SivilstandskodePDL.SEPARERT,
+                    gyldigFom = LocalDate.of(2023, 5, 12),
+                    bekreftelsesdato = null,
+                    master = "PDL",
+                    registrert = LocalDateTime.parse("2023-06-13T14:44:16"),
+                    historisk = false,
+                ),
+            ),
+            behandledeSivilstandsopplysninger = emptyList(),
+            endreSivilstand = null,
+        )
+
+        fun aktivPeriodeErFørVirkningstidspunkt() = SivilstandRequest(
+            fødselsdatoBM = LocalDate.parse("1980-01-01"),
+            innhentedeOffentligeOpplysninger =
+            listOf(
+                SivilstandGrunnlagDto(
+                    personId = "12345678901",
+                    type = SivilstandskodePDL.GIFT,
+                    gyldigFom = null,
+                    bekreftelsesdato = null,
+                    master = "PDL",
+                    registrert = null,
+                    historisk = true,
+                ),
+                SivilstandGrunnlagDto(
+                    personId = "12345678901",
+                    type = SivilstandskodePDL.UGIFT,
+                    gyldigFom = null,
+                    bekreftelsesdato = null,
+                    master = "PDL",
+                    registrert = null,
+                    historisk = true,
+                ),
+                SivilstandGrunnlagDto(
+                    personId = "12345678901",
+                    type = SivilstandskodePDL.SEPARERT,
+                    gyldigFom = LocalDate.of(2024, 4, 17),
+                    bekreftelsesdato = null,
+                    master = "PDL",
+                    registrert = LocalDateTime.parse("2023-06-13T14:44:16"),
+                    historisk = false,
+                ),
+            ),
+            behandledeSivilstandsopplysninger = emptyList(),
             endreSivilstand = null,
         )
     }

--- a/bidrag-sivilstand/src/test/kotlin/no/nav/bidrag/sivilstand/service/SivilstandServiceV2Test.kt
+++ b/bidrag-sivilstand/src/test/kotlin/no/nav/bidrag/sivilstand/service/SivilstandServiceV2Test.kt
@@ -22,22 +22,18 @@ internal class SivilstandServiceV2Test {
 
         assertSoftly {
             Assertions.assertNotNull(resultat)
-            resultat.size shouldBe 4
+            resultat.size shouldBe 3
             resultat[0].periodeFom shouldBe LocalDate.of(2010, 9, 1)
-            resultat[0].periodeTom shouldBe LocalDate.of(2011, 1, 31)
-            resultat[0].sivilstandskode shouldBe Sivilstandskode.UKJENT
+            resultat[0].periodeTom shouldBe LocalDate.of(2017, 7, 31)
+            resultat[0].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
 
-            resultat[1].periodeFom shouldBe LocalDate.of(2011, 2, 1)
-            resultat[1].periodeTom shouldBe LocalDate.of(2017, 7, 31)
-            resultat[1].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
+            resultat[1].periodeFom shouldBe LocalDate.of(2017, 8, 1)
+            resultat[1].periodeTom shouldBe LocalDate.of(2021, 8, 31)
+            resultat[1].sivilstandskode shouldBe Sivilstandskode.GIFT_SAMBOER
 
-            resultat[2].periodeFom shouldBe LocalDate.of(2017, 8, 1)
-            resultat[2].periodeTom shouldBe LocalDate.of(2021, 8, 31)
-            resultat[2].sivilstandskode shouldBe Sivilstandskode.GIFT_SAMBOER
-
-            resultat[3].periodeFom shouldBe LocalDate.of(2021, 9, 1)
-            resultat[3].periodeTom shouldBe null
-            resultat[3].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
+            resultat[2].periodeFom shouldBe LocalDate.of(2021, 9, 1)
+            resultat[2].periodeTom shouldBe null
+            resultat[2].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
         }
     }
 
@@ -816,6 +812,54 @@ internal class SivilstandServiceV2Test {
 
             // Første periode får kilde satt til Offentlig pga matchende offentlig periode
             resultat[0].periodeFom shouldBe LocalDate.of(2023, 1, 1)
+            resultat[0].periodeTom shouldBe null
+            resultat[0].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
+            resultat[0].kilde shouldBe Kilde.OFFENTLIG
+        }
+    }
+
+    @Test
+    fun `Test at gyldigFom blir satt lik BMs fødselsdato ved status UGIFT`() {
+        sivilstandServiceV2 = SivilstandServiceV2()
+        val mottattSivilstand = TestUtil.gyldigFomLikFødselsdatoUgift()
+
+        val virkningstidspunkt1 = LocalDate.of(2022, 8, 1)
+        val resultat = sivilstandServiceV2.beregn(virkningstidspunkt1, mottattSivilstand)
+
+        assertSoftly {
+            Assertions.assertNotNull(resultat)
+            resultat.size shouldBe 3
+
+            resultat[0].periodeFom shouldBe LocalDate.of(2022, 8, 1)
+            resultat[0].periodeTom shouldBe LocalDate.of(2022, 12, 31)
+            resultat[0].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
+            resultat[0].kilde shouldBe Kilde.OFFENTLIG
+
+            resultat[1].periodeFom shouldBe LocalDate.of(2023, 1, 1)
+            resultat[1].periodeTom shouldBe LocalDate.of(2023, 4, 30)
+            resultat[1].sivilstandskode shouldBe Sivilstandskode.GIFT_SAMBOER
+            resultat[1].kilde shouldBe Kilde.OFFENTLIG
+
+            resultat[2].periodeFom shouldBe LocalDate.of(2023, 5, 1)
+            resultat[2].periodeTom shouldBe null
+            resultat[2].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
+            resultat[2].kilde shouldBe Kilde.OFFENTLIG
+        }
+    }
+
+    @Test
+    fun `Test at det ikke genereres periode med UKJENT hvis aktiv periode er før virkningstidspunkt`() {
+        sivilstandServiceV2 = SivilstandServiceV2()
+        val mottattSivilstand = TestUtil.aktivPeriodeErFørVirkningstidspunkt()
+
+        val virkningstidspunkt1 = LocalDate.of(2024, 4, 1)
+        val resultat = sivilstandServiceV2.beregn(virkningstidspunkt1, mottattSivilstand)
+
+        assertSoftly {
+            Assertions.assertNotNull(resultat)
+            resultat.size shouldBe 1
+
+            resultat[0].periodeFom shouldBe LocalDate.of(2024, 4, 1)
             resultat[0].periodeTom shouldBe null
             resultat[0].sivilstandskode shouldBe Sivilstandskode.BOR_ALENE_MED_BARN
             resultat[0].kilde shouldBe Kilde.OFFENTLIG


### PR DESCRIPTION
…lstand, dropper også logisk kontroll hvis aktiv status har gyldigFom før/lik virkningstidspunkt